### PR TITLE
Update 18-02-2022

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,6 @@ This is the script version, a [mod version](https://github.com/TheTimidShade/Tim
 **For help with troubleshooting, questions or feedback, join my [Discord](https://discord.gg/8Y2ENWQMpK)**
 ___
 
-There are two types of emissions to choose from:
-
-**Map Sweep** - The emission will sweep the map from one side to the other, so the time at which units are hit by the wave is dynamic depending on their position on the map. The 'Wave Speed', 'Show Emission on Map' and 'Approach Direction' parameters only apply to this emission type.
-
-**Fixed Distance** - The emission will start at a fixed distance away from players so all players and units on the map are hit at the same time. Since the emission is fixed to the player, no matter how fast you fly away from the wave it will still hit you, so this can look weird from aircraft. Mainly suited towards player only/infantry/RP missions. (This was v1 before I designed the map sweep version)
-
 To shelter yourself from the emission, you must have a structure or vehicle considered to be shelter above your head within 30m. By default, objects considered shelter are anything that inherits from the classes 'Building', 'Car', 'Tank', 'Air' or 'Ship'. These classes can be adjusted in the settings if desired.
 
 ___
@@ -76,6 +70,19 @@ ___
 
 ## Changelog
 Read below for complete changelog history.
+
+### 18/02/2022
+- Fixed distance emission is no longer supported.
+- Camera shake is now tied to the camera's distance to the emission wave rather than the player's and sounds are now played relative to the camera.
+- Increased audible distance for emission pulse sounds and create them further away so that they are still audible when moving rapidly.
+- Adjusted light source attenuation so the sky light isn't concentrated around the player.
+- The player is no longer affected by the emission wave if they have damage disabled.
+- AI now use the same shelter check as players.
+- Added a parameter to select what effect the emission has on non-flying vehicles (ground vehicles/ships/landed aircraft).
+- Cleaned up damage related functions so there should be no clash between player/AI effect and aircraft/vehicle effect parameters.
+- Fixed an issue where lightning bolts would not appear correctly in multiplayer.
+- Static weapons are not affected by the emission.
+- Updated default settings for 'Start Random Emissions' ZEN module (defaults were still in seconds rather than minutes).
 
 ### 19/11/2021
 - Added Korean translation by Taru.

--- a/init.sqf
+++ b/init.sqf
@@ -1,6 +1,6 @@
-tts_emission_emissionType = 0;
 tts_emission_playerEffect = 0;
 tts_emission_aiEffect = 1;
+tts_emission_vehicleEffect = 3;
 tts_emission_aircraftEffect = 0;
 tts_emission_useSirenObject = false;
 tts_emission_sirenType = 0;

--- a/scripts/tts_emission/functions/effects/fn_flash.sqf
+++ b/scripts/tts_emission/functions/effects/fn_flash.sqf
@@ -15,8 +15,9 @@
 params ["_brightness", "_delay"];
 
 private _flash = "#lightpoint" createVehicleLocal (getPos player);
-private _flashPos = getPosASL player;
-_flash setPosASL [_flashPos#0, _flashPos#1, _flashPos#2+1000];
+private _flashPos = (positionCameraToWorld [0,0,0]) getPos [random 4000, random 360];
+_flashPos set [2, 1400];
+_flash setPosASL _flashPos;
 _flash setLightBrightness _brightness;
 _flash setLightAmbient [1,1,1];
 _flash setLightColor [1,1,1];

--- a/scripts/tts_emission/functions/effects/fn_handleLighting.sqf
+++ b/scripts/tts_emission/functions/effects/fn_handleLighting.sqf
@@ -13,25 +13,28 @@
 
 if (!hasInterface) exitWith {};
 
-private _mainBrightness = 110;
+private _mainBrightness = 0.4;
 private _delay = 60;
 
 private _mainLight = "#lightpoint" createVehicleLocal (getPos player);
 _mainLight setLightBrightness 0;
 //_mainLight setLightAmbient [1,0.5,0.5]; // [0.2,0,0]
 _mainLight setLightColor [1,0.5,0.5];
-_mainLight lightAttachObject [player, [0,0,1000]];
+_mainLight setLightAttenuation [2,4,4.31918e-005,0];
+_mainLight lightAttachObject [player, [0,0,5000]];
 
-for "_i" from 0 to _mainBrightness do {
+private _step = _mainBrightness/_delay/5;
+
+for "_i" from 0 to _mainBrightness step _step do {
 	_mainLight setLightBrightness _i;
-	sleep (_delay/_mainBrightness);
+	sleep 0.2;
 };
 
 waitUntil {sleep 1; tts_emission_progressState > 4};
 
-for "_i" from 0 to _mainBrightness do {
+for "_i" from 0 to _mainBrightness step _step do {
 	_mainLight setLightBrightness _mainBrightness - _i;
-	sleep (_delay/_mainBrightness);
+	sleep 0.2;
 };
 
 deleteVehicle _mainLight;

--- a/scripts/tts_emission/functions/effects/fn_soundAbovePlayer.sqf
+++ b/scripts/tts_emission/functions/effects/fn_soundAbovePlayer.sqf
@@ -18,11 +18,11 @@ params ["_sound"];
 private _source = "Sign_Sphere10cm_F" createVehicleLocal [0,0,0];
 _source hideObject true;
 private _direction = round random 360;
-private _sourcePos = player getRelPos [15 + (random 10), _direction];
+private _sourcePos = (positionCameraToWorld [0,0,0]) getPos [50 + (random 50), _direction];
 private _playerHeight = (getPosASL player)#2;
-_source setPosASL [_sourcePos#0, _sourcePos#1, _playerHeight+20];
+_source setPosASL [_sourcePos#0, _sourcePos#1, ((positionCameraToWorld [0,0,0])#2) + 30];
 
-_source say3D [_sound, 400, 1, false];
+_source say3D [_sound, 1200, 1, false];
 
 sleep 30;
 

--- a/scripts/tts_emission/functions/effects/fn_waveEffectMapSweeper.sqf
+++ b/scripts/tts_emission/functions/effects/fn_waveEffectMapSweeper.sqf
@@ -45,11 +45,11 @@ _waveObject spawn { // handle sound
 	params ["_waveObject", "_distance"];
 	enableCamShake true;
 	while {alive _waveObject} do {
-		waitUntil {sleep 0.1; !alive _waveObject || {player distance2D _waveObject < 3000}};
+		waitUntil {sleep 0.1; !alive _waveObject || {(positionCameraToWorld [0,0,0]) distance2D _waveObject < 3000}}; // play wave approach sound within 3000m
 		if (alive _waveObject) then {playSound "blowout_wave_01"};
-		waitUntil {sleep 0.1; !alive _waveObject || {player distance2D _waveObject < 1400}};
-		while {alive _waveObject && {player distance2D _waveObject < 1400}} do {
-			private _shakeCoef = 1-((player distance _waveObject)/_distance); // shake intensifies as wave approaches
+		waitUntil {sleep 0.1; !alive _waveObject || {(positionCameraToWorld [0,0,0]) distance2D _waveObject < _distance}}; // camera shake within 1400m of wave
+		while {alive _waveObject && {(positionCameraToWorld [0,0,0]) distance2D _waveObject < _distance}} do {
+			private _shakeCoef = 1-(((positionCameraToWorld [0,0,0]) distance _waveObject)/_distance); // shake intensifies as wave approaches
 			addCamShake [3*(_shakeCoef^2), 2, 10];
 			sleep 0.2;
 		};

--- a/scripts/tts_emission/functions/fn_damageNonPlayer.sqf
+++ b/scripts/tts_emission/functions/fn_damageNonPlayer.sqf
@@ -21,48 +21,94 @@ params [
 if (count _unitArray < 1) exitWith {};
 
 private _ace_enabled = isClass(configFile >> "CfgPatches" >> "ace_main");
-private _zombiesEnabled = isClass (configFile >> "CfgPatches" >> "rvg_zeds") || isClass (configFile >> "CfgPatches" >> "Ryanzombies");
+
+// helper function to determine whether or not the effects apply to specific units
+private _fnc_isFirstCrew = {
+	params ["_unit", "_vehicle"];
+
+	private _playerInCrew = false;
+	{if (isPlayer _x) exitWith {_playerInCrew = true;};} forEach (crew _vehicle);
+	
+	((crew _vehicle)#0 == _unit && !_playerInCrew)
+};
 
 private _disabledUnits = [];
 {
 	private _unit = _x;
-	if (!(_unit call tts_emission_fnc_isZombie)) then { // if the unit is not a zombie and isn't a player
-		_vehicle = vehicle _unit;
-		if (_vehicle isKindOf "AIR" && (getPosATL _vehicle)#2 > 15 && tts_emission_aircraftEffect != 2) then {
-			private _playerInCrew = false;
-			{if (isPlayer _x) exitWith {_playerInCrew = true;};} forEach (crew _vehicle);
-			
-			if ((crew _vehicle)#0 == _unit && !_playerInCrew) then { // only bolt vehicle if the unit is the first in the crew and there are no players
-				if (tts_emission_aircraftEffect == 0) then {
-					[_vehicle, nil, true] call BIS_fnc_moduleLightning; // vehicle gets blown out the sky
-				} else {
-					[_vehicle, ["HitEngine", 1]] remoteExec ["setHitPointDamage", _vehicle, false];
+	if (_unit call tts_emission_fnc_isZombie) then { continue }; // skip units that are zombies
+	if (_unit getVariable ["tts_emission_affectedByWave", false]) then { continue }; // skip units that have already been affected by the wave in the last 10s
+	
+	// check unit
+	if (!(_unit call tts_emission_fnc_isSafe) || tts_emission_aiEffect in [2,3]) then { // check if they are safe from the emission
+		if (tts_emission_aiEffect in [0,2] && !(_unit call tts_emission_fnc_hasProtection)) then { // if emission is lethal to ai
+			_unit setDamage 1;
+			_unit setVariable ["tts_emission_affectedByWave", true, true];
+		} else { // if emission is non-lethal disable them temporarily
+			if (!(_unit getVariable ["tts_emission_ai_isUnconscious", false])) then {
+				private _unitStatus = [ // preserve unit AI state to avoid conflict
+					_unit checkAIFeature "MOVE",
+					_unit checkAIFeature "TARGET",
+					_unit checkAIFeature "AUTOTARGET",
+					_unit checkAIFeature "WEAPONAIM"
+				];
+				{[_unit, _x] remoteExec ["disableAI", _unit, false];} forEach ["MOVE", "AUTOTARGET", "TARGET", "WEAPONAIM"];
+				_disabledUnits pushBack [_unit, _unitStatus];
+				[_unit, "unconscious"] remoteExec ["playMoveNow", _unit, false];
+				_unit setVariable ["tts_emission_ai_isUnconscious", true, true];
+				_unit setVariable ["tts_emission_affectedByWave", true, true];
+			};
+
+			//_unit setUnconscious true;
+			//_unit spawn {sleep 15; _this setUnconscious false;};
+		};
+	};
+
+	// check unit's vehicle
+	_vehicle = vehicle _unit;
+	if (_vehicle != _unit && [_unit, _vehicle] call _fnc_isFirstCrew && {!(_vehicle isKindOf "StaticWeapon")}) then {
+		private _isFlying = (surfaceIsWater getPos _vehicle && (getPosASL _vehicle)#2 > 10) || (!surfaceIsWater getPos _vehicle && (getPosASL _vehicle)#2 > 10 && !isTouchingGround _vehicle);
+		
+		if (_isFlying) then { // for flying vehicles, apply aircraft effect
+			switch (tts_emission_aircraftEffect) do {
+				case 0: {
+					private _target = createSimpleObject ["Land_HelipadEmpty_F", getPosATL _vehicle];
+					_target attachTo [_vehicle, [0,0,0]];
+					[_target, nil, true] remoteExec ["BIS_fnc_moduleLightning", 0, false]; // lightning bolt
+				};
+				case 1: {
+					[_vehicle, ["HitEngine", 1]] remoteExec ["setHitPointDamage", _vehicle, false]; // engine is disabled
+				};
+				case 2: {
+					continue
 				};
 			};
-		} else { // if the unit is not in an air vehicle
-			if (!(_unit call tts_emission_fnc_isSafe) || tts_emission_aiEffect in [2,3]) then { // check if they are safe from the emission
-				if (tts_emission_aiEffect in [0,2] && !(_unit call tts_emission_fnc_hasProtection)) then { // if emission is lethal to ai
-					_unit setDamage 1;
-				} else { // if emission is non-lethal disable them temporarily
-					if (!(_unit getVariable ["tts_emission_ai_isUnconscious", false])) then {
-						private _unitStatus = [ // preserve unit AI state to avoid conflict
-							_unit checkAIFeature "MOVE",
-							_unit checkAIFeature "TARGET",
-							_unit checkAIFeature "AUTOTARGET",
-							_unit checkAIFeature "WEAPONAIM"
-						];
-						{[_unit, _x] remoteExec ["disableAI", _unit, false];} forEach ["MOVE", "AUTOTARGET", "TARGET", "WEAPONAIM"];
-						_disabledUnits pushBack [_unit, _unitStatus];
-						[_unit, "unconscious"] remoteExec ["playMoveNow", _unit, false];
-						_unit setVariable ["tts_emission_ai_isUnconscious", true, true];
-					};
-
-					//_unit setUnconscious true;
-					//_unit spawn {sleep 15; _this setUnconscious false;};
+		} else { // for other vehicles apply standard vehicle effect
+			switch (tts_emission_vehicleEffect) do {
+				case 0: {
+					private _target = createSimpleObject ["Land_HelipadEmpty_F", getPosATL _vehicle];
+					_target attachTo [_vehicle, [0,0,0]];
+					[_target, nil, true] remoteExec ["BIS_fnc_moduleLightning", 0, false]; // lightning bolt
+				};
+				case 1: {
+					[_vehicle, ["HitEngine", 1]] remoteExec ["setHitPointDamage", _vehicle, false]; // engine is disabled
+				};
+				case 2: {
+					if (isEngineOn _vehicle) then { // vehicle gets lightning bolted if engine is on
+						private _target = createSimpleObject ["Land_HelipadEmpty_F", getPosATL _vehicle];
+						_target attachTo [_vehicle, [0,0,0]];
+						[_target, nil, true] remoteExec ["BIS_fnc_moduleLightning", 0, false]; // lightning bolt
+					}; 
+				};
+				case 3: {
+					if (isEngineOn _vehicle) then {[_vehicle, ["HitEngine", 1]] remoteExec ["setHitPointDamage", _vehicle, false];}; // engine is disabled if engine is on
+				};
+				case 4: {
+					continue
 				};
 			};
 		};
 	};
+	
 	sleep 0.01; // 100 units per second
 } forEach _unitArray;
 

--- a/scripts/tts_emission/functions/fn_damagePlayer.sqf
+++ b/scripts/tts_emission/functions/fn_damagePlayer.sqf
@@ -12,43 +12,86 @@
 */
 
 if (!hasInterface) exitWith {};
-if (!alive player) exitWith {};
+if (!alive player || !isDamageAllowed player) exitWith {};
 if (missionNamespace getVariable ["tts_emission_damagePlayerRunning", false]) exitWith {}; // make sure the script cannot run more than once at a time
 if (tts_emission_playerEffect == 4) exitWith {}; // do nothing since player emission damage is disabled
 
 private _ace_enabled = isClass(configFile >> "CfgPatches" >> "ace_main");
-private _zombiesEnabled = isClass (configFile >> "CfgPatches" >> "rvg_zeds") || isClass (configFile >> "CfgPatches" >> "Ryanzombies");
 
-tts_emission_damagePlayerRunning = true;
-_vehicle = vehicle player;
-if (_vehicle isKindOf "AIR" && (getPosATL _vehicle)#2 > 15 && tts_emission_aircraftEffect != 2) then { // if player is in air vehicle strike them out of the sky
+// helper function to determine whether or not the effect should be run on this player
+private _fnc_isFirstCrew = {
+	params ["_vehicle"];
+
 	private _playerCrew = [];
 	{
 		if (isPlayer _x) then {_playerCrew pushBackUnique _x;};
-	} forEach crew (vehicle player); 
-	
-	if (_playerCrew#0 == player) then { // only disable vehicle if player is the first in the crew to prevent duplicate
-		if (tts_emission_aircraftEffect == 0) then {
-			[_vehicle, nil, true] call BIS_fnc_moduleLightning; // vehicle gets blown out the sky
+	} forEach crew (vehicle player);
+
+	(_playerCrew#0 == player)
+};
+
+tts_emission_damagePlayerRunning = true;
+
+// check player status
+if ((!(player call tts_emission_fnc_isSafe) || tts_emission_playerEffect in [2,3])) then { // check if they are safe from the emission
+	if ((tts_emission_playerEffect == 0 && player call tts_emission_fnc_hasProtection) || tts_emission_playerEffect in [1,3]) then { // if they have protection, knock them out if ACE is enabled, or knock them over if not
+		if (_ace_enabled) then {
+			[player, true, 10, true] call ace_medical_fnc_setUnconscious; // force wakeup after 15 seconds if vitals are stable
+			[] spawn {sleep 10; [] spawn tts_emission_fnc_psyEffect;}; // sleep so can still see ppfx
 		} else {
-			[_vehicle, ["hitEngine", 1]] remoteExec ["setHitPointDamage", _vehicle, false];
+			player setUnconscious true;
+			[] spawn tts_emission_fnc_psyEffect;
+			[] spawn {sleep 15; player setUnconscious false;};
 		};
+	} else { // if they don't have protection instantly kill them
+		player setDamage 1;
 	};
-} else { // if the player is not in an air vehicle
-	if ((!(player call tts_emission_fnc_isSafe) || tts_emission_playerEffect in [2,3]) && isDamageAllowed player) then { // check if they are safe from the emission
-		if ((tts_emission_playerEffect == 0 && player call tts_emission_fnc_hasProtection) || tts_emission_playerEffect in [1,3]) then { // if they have protection, knock them out if ACE is enabled, or knock them over if not
-			if (_ace_enabled) then {
-				[player, true, 10, true] call ace_medical_fnc_setUnconscious; // force wakeup after 15 seconds if vitals are stable
-				[] spawn {sleep 10; [] spawn tts_emission_fnc_psyEffect;}; // sleep so can still see ppfx
-			} else {
-				player setUnconscious true;
-				[] spawn tts_emission_fnc_psyEffect;
-				[] spawn {sleep 15; player setUnconscious false;};
+};
+
+// check player vehicle status
+_vehicle = vehicle player;
+if (_vehicle != player && [player, _vehicle] call _fnc_isFirstCrew && {!(_vehicle isKindOf "StaticWeapon")}) then {
+	private _isFlying = (surfaceIsWater getPos _vehicle && (getPosASL _vehicle)#2 > 10) || (!surfaceIsWater getPos _vehicle && (getPosASL _vehicle)#2 > 10 && !isTouchingGround _vehicle);
+	
+	if (_isFlying) then { // for flying vehicles, apply aircraft effect
+			switch (tts_emission_aircraftEffect) do {
+				case 0: {
+					private _target = createSimpleObject ["Land_HelipadEmpty_F", getPosATL _vehicle];
+					_target attachTo [_vehicle, [0,0,0]];
+					[_target, nil, true] remoteExec ["BIS_fnc_moduleLightning", 0, false]; // lightning bolt
+				};
+				case 1: {
+					[_vehicle, ["HitEngine", 1]] remoteExec ["setHitPointDamage", _vehicle, false]; // engine is disabled
+				};
+				case 2: {
+					continue
+				};
 			};
-		} else { // if they don't have protection instantly kill them
-			player setDamage 1;
+		} else { // for other vehicles apply standard vehicle effect
+			switch (tts_emission_vehicleEffect) do {
+				case 0: {
+					private _target = createSimpleObject ["Land_HelipadEmpty_F", getPosATL _vehicle];
+					_target attachTo [_vehicle, [0,0,0]];
+					[_target, nil, true] remoteExec ["BIS_fnc_moduleLightning", 0, false]; // lightning bolt
+				};
+				case 1: {
+					[_vehicle, ["HitEngine", 1]] remoteExec ["setHitPointDamage", _vehicle, false]; // engine is disabled
+				};
+				case 2: {
+					if (isEngineOn _vehicle) then { // vehicle gets lightning bolted if engine is on
+						private _target = createSimpleObject ["Land_HelipadEmpty_F", getPosATL _vehicle];
+						_target attachTo [_vehicle, [0,0,0]];
+						[_target, nil, true] remoteExec ["BIS_fnc_moduleLightning", 0, false]; // lightning bolt
+					}; 
+				};
+				case 3: {
+					if (isEngineOn _vehicle) then {[_vehicle, ["HitEngine", 1]] remoteExec ["setHitPointDamage", _vehicle, false];}; // engine is disabled if engine is on
+				};
+				case 4: {
+					continue
+				};
+			};
 		};
-	};
 };
 
 sleep 10; // wait 10 seconds before player can be affected by emission wave again

--- a/scripts/tts_emission/functions/fn_isSafe.sqf
+++ b/scripts/tts_emission/functions/fn_isSafe.sqf
@@ -20,17 +20,14 @@ if (((getPosASL _unit)#2) <= -2) exitWith {true}; // if unit is more than 2m und
 if ([_unit] call tts_emission_fnc_isImmune) exitWith {true}; // if the unit is immune they are safe
 
 private _isSafe = false;
-if (isPlayer _unit) then {
-	private _eyePos = eyePos _unit;
-	private _endPos = [_eyePos#0, _eyePos#1, _eyePos#2+30];
 
-	private _intersectObjects = lineIntersectsWith [_eyePos, _endPos, _unit, objNull, true]; // check if there are any objects above player's head for 5m
+private _eyePos = eyePos _unit;
+private _endPos = [_eyePos#0, _eyePos#1, _eyePos#2+30];
 
-	{
-		if (_x call tts_emission_fnc_isSafeType) exitWith {_isSafe = true;}; // check if there is an object which is considered shelter above player
-	} forEach _intersectObjects;
-} else {
-	private _nearbyBuildings = _unit nearObjects ["Building", 20]; // any AI within 20m of a building are considered safe
-	_isSafe = if ({!(typeOf _x == "GroundWeaponHolder")} count _nearbyBuildings > 0) then {true} else {false};
-};
+private _intersectObjects = lineIntersectsWith [_eyePos, _endPos, _unit, objNull, true]; // check if there are any objects above player's head for 5m
+
+{
+	if (_x call tts_emission_fnc_isSafeType) exitWith {_isSafe = true;}; // check if there is an object which is considered shelter above player
+} forEach _intersectObjects;
+
 _isSafe

--- a/scripts/tts_emission/functions/fn_startEmission.sqf
+++ b/scripts/tts_emission/functions/fn_startEmission.sqf
@@ -17,9 +17,10 @@ if (tts_emission_emissionIsActive) exitWith {}; // if there is already an emissi
 
 // configure settings if they are not defined or invalid
 /*
-	tts_emission_emissionType - 0 = map sweeper, wave sweeps map from top to bottom, 1 = fixed distance, wave hits at same time for everyone on the map
+	tts_emission_emissionType - 0 = map sweeper, wave sweeps map from top to bottom, 1 = fixed distance
 	tts_emission_playerEffect - 0 = kill unsheltered units, 1 = knockout unsheltered units, 2 = kill all, 3 = knockout all, 4 = no effect
 	tts_emission_aiEffect - 0 = kill unsheltered units, 1 = knockout unsheltered units, 2 = kill all, 3 = knockout all, 4 = no effect
+	tts_emission_vehicleEffect - 0 = bolt vehicle, 1 = disable engine, 2 = bolt vehicle if engine on, 3 = disable engine if engine on, 4 = no effect
 	tts_emission_aircraftEffect - 0 = strike aircraft, 1 = disable aircraft, 2 = no effect
 	tts_emission_sirenType - 0 = classic, 1 = dramatic, 2 = none
 	tts_emission_useSirenObject - true = Siren warning will be emitted from object instead of played in player's ears
@@ -31,9 +32,10 @@ if (tts_emission_emissionIsActive) exitWith {}; // if there is already an emissi
 */
 
 // if not defined, set to default
-if (isNil "tts_emission_emissionType") then {tts_emission_emissionType = 0;};
+if (isNil "tts_emission_emissionType") then {tts_emission_emissionType = 0;}; // FIXED DISTANCE NO LONGER SUPPORTED
 if (isNil "tts_emission_playerEffect") then {tts_emission_playerEffect = 0;};
 if (isNil "tts_emission_aiEffect") then {tts_emission_aiEffect = 1;};
+if (isNil "tts_emission_vehicleEffect") then {tts_emission_vehicleEffect = 3;};
 if (isNil "tts_emission_aircraftEffect") then {tts_emission_aircraftEffect = 0;};
 if (isNil "tts_emission_sirenType") then {tts_emission_sirenType = 0;};
 if (isNil "tts_emission_useSirenObject") then {tts_emission_useSirenObject = false;};
@@ -49,6 +51,7 @@ if (isNil "tts_emission_disableRain") then {tts_emission_disableRain = false;};
 if (!(tts_emission_emissionType in [0,1])) then {tts_emission_emissionType = 0;};
 if (!(tts_emission_playerEffect in [0,1,2,3,4])) then {tts_emission_playerEffect = 0;};
 if (!(tts_emission_aiEffect in [0,1,2,3,4])) then {tts_emission_aiEffect = 1;};
+if (!(tts_emission_vehicleEffect in [0,1,2,3,4])) then {tts_emission_vehicleEffect = 3;};
 if (!(tts_emission_aircraftEffect in [0,1,2])) then {tts_emission_aircraftEffect = 0;};
 if (!(tts_emission_sirenType in [0,1,2])) then {tts_emission_sirenType = 0;};
 if (!(tts_emission_useSirenObject in [true,false])) then {tts_emission_useSirenObject = false;};
@@ -62,6 +65,7 @@ if (!(tts_emission_disableRain in [true,false])) then {tts_emission_disableRain 
 	"tts_emission_emissionType",
 	"tts_emission_playerEffect",
 	"tts_emission_aiEffect",
+	"tts_emission_vehicleEffect",
 	"tts_emission_aircraftEffect",
 	"tts_emission_sirenType",
 	"tts_emission_useSirenObject",

--- a/scripts/tts_emission/functions/zen/fn_zen_moduleChangeSettings.sqf
+++ b/scripts/tts_emission/functions/zen/fn_zen_moduleChangeSettings.sqf
@@ -6,9 +6,10 @@
 	if (tts_emission_emissionIsActive) then {systemChat localize "STR_tts_emission_moduleChangeSettings_warning";};
 
 	// set up settings if they are undefined
-	if (isNil "tts_emission_emissionType") then {tts_emission_emissionType = 0;};
+	//if (isNil "tts_emission_emissionType") then {tts_emission_emissionType = 0;};
 	if (isNil "tts_emission_playerEffect") then {tts_emission_playerEffect = 0;};
 	if (isNil "tts_emission_aiEffect") then {tts_emission_aiEffect = 1;};
+	if (isNil "tts_emission_vehicleEffect") then {tts_emission_vehicleEffect = 3;};
 	if (isNil "tts_emission_aircraftEffect") then {tts_emission_aircraftEffect = 0;};
 	if (isNil "tts_emission_sirenType") then {tts_emission_sirenType = 0;};
 	if (isNil "tts_emission_useSirenObject") then {tts_emission_useSirenObject = false;};
@@ -29,19 +30,19 @@
 	[
 		"STR_tts_emission_moduleChangeSettings_heading", // title
 		[ // array of controls for dialog
-			["COMBO", ["STR_tts_emission_moduleChangeSettings_emissionType", "STR_tts_emission_moduleChangeSettings_emissionType_desc"],
+			/*["COMBO", ["STR_tts_emission_moduleChangeSettings_emissionType", "STR_tts_emission_moduleChangeSettings_emissionType_desc"],
 				[ // control args
 					[0, 1], // return values
 					["STR_tts_emission_moduleChangeSettings_emissionType_mapSweep", "STR_tts_emission_moduleChangeSettings_emissionType_fixedDistance"], // labels
 					tts_emission_emissionType // element 0 is default selected
 				],
 				true // force default
-			],
+			],*/
 			["COMBO", ["STR_tts_emission_moduleChangeSettings_playerEffect", "STR_tts_emission_moduleChangeSettings_playerEffect_desc"],
 				[ // control args
 					[0, 1, 2, 3, 4], // return values
 					["STR_tts_emission_moduleChangeSettings_emissionEffect_killUnsheltered", "STR_tts_emission_moduleChangeSettings_emissionEffect_knockoutUnsheltered", "STR_tts_emission_moduleChangeSettings_emissionEffect_killAll", "STR_tts_emission_moduleChangeSettings_emissionEffect_knockoutAll", "STR_tts_emission_moduleChangeSettings_emissionEffect_noEffect"], // labels
-					tts_emission_playerEffect // element 0 is default selected
+					tts_emission_playerEffect
 				],
 				true // force default
 			],
@@ -49,7 +50,15 @@
 				[ // control args
 					[0, 1, 2, 3, 4], // return values
 					["STR_tts_emission_moduleChangeSettings_emissionEffect_killUnsheltered", "STR_tts_emission_moduleChangeSettings_emissionEffect_knockoutUnsheltered", "STR_tts_emission_moduleChangeSettings_emissionEffect_killAll", "STR_tts_emission_moduleChangeSettings_emissionEffect_knockoutAll", "STR_tts_emission_moduleChangeSettings_emissionEffect_noEffect"], // labels
-					tts_emission_aiEffect // element 0 is default selected
+					tts_emission_aiEffect
+				],
+				true // force default
+			],
+			["COMBO", ["STR_tts_emission_moduleChangeSettings_vehicleEffect", "STR_tts_emission_moduleChangeSettings_vehicleEffect_desc"],
+				[ // control args
+					[0, 1, 2, 3, 4], // return values
+					["STR_tts_emission_moduleChangeSettings_aircraftEffect_lightningBolt", "STR_tts_emission_moduleChangeSettings_vehicleEffect_disableEngine", "STR_tts_emission_moduleChangeSettings_vehicleEffect_lightningBolt_engineOn", "STR_tts_emission_moduleChangeSettings_vehicleEffect_disableEngine_engineOn", "STR_tts_emission_moduleChangeSettings_emissionEffect_noEffect"], // labels
+					tts_emission_vehicleEffect
 				],
 				true // force default
 			],
@@ -57,7 +66,7 @@
 				[ // control args
 					[0, 1, 2], // return values
 					["STR_tts_emission_moduleChangeSettings_aircraftEffect_lightningBolt", "STR_tts_emission_moduleChangeSettings_aircraftEffect_engineFailure", "STR_tts_emission_moduleChangeSettings_emissionEffect_noEffect"], // labels
-					tts_emission_aircraftEffect // element 0 is default selected
+					tts_emission_aircraftEffect 
 				],
 				true // force default
 			],
@@ -65,7 +74,7 @@
 				[ // control args
 					[0, 1, 2], // return values
 					["STR_tts_emission_moduleChangeSettings_sirenType_classic", "STR_tts_emission_moduleChangeSettings_sirenType_dramatic", "STR_tts_emission_none"], // labels
-					tts_emission_sirenType // element 0 is default selected
+					tts_emission_sirenType
 				],
 				true // force default
 			],
@@ -131,24 +140,28 @@
 		{ // code run on dialog closed (only run if OK is clicked)
 			params ["_dialogResult", "_args"];
 
-			tts_emission_emissionType = _dialogResult#0;
-			tts_emission_playerEffect = _dialogResult#1;
-			tts_emission_aiEffect = _dialogResult#2;
-			tts_emission_aircraftEffect = _dialogResult#3;
-			tts_emission_sirenType = _dialogResult#4;
-			tts_emission_useSirenObject = _dialogResult#5;
-			tts_emission_protectionEquipment = (_dialogResult#6) splitString ",";
-			tts_emission_shelterTypes = (_dialogResult#7) splitString ",";
-			tts_emission_immuneUnits = (_dialogResult#8) splitString ",";
-			tts_emission_waveSpeed = parseNumber (_dialogResult#9);
-			tts_emission_approachDirection = ["N", "E", "S", "W"]#(_dialogResult#10);
-			tts_emission_showEmissionOnMap = _dialogResult#11;
-			tts_emission_disableRain = _dialogResult#12;
+			_dialogResult params ["_playerEffect", "_aiEffect", "_vehicleEffect", "_aircraftEffect", "_sirenType", "_useSirenObject", "_protectionEquipment", "_shelterTypes", "_immuneUnits", "_waveSpeed", "_approachDirection", "_showEmissionOnMap", "_disableRain"];
+
+			//tts_emission_emissionType = _dialogResult#0;
+			tts_emission_playerEffect = _playerEffect;
+			tts_emission_aiEffect = _aiEffect;
+			tts_emission_vehicleEffect = _vehicleEffect;
+			tts_emission_aircraftEffect = _aircraftEffect;
+			tts_emission_sirenType = _sirenType;
+			tts_emission_useSirenObject = _useSirenObject;
+			tts_emission_protectionEquipment = (_protectionEquipment) splitString ",";
+			tts_emission_shelterTypes = (_shelterTypes) splitString ",";
+			tts_emission_immuneUnits = (_immuneUnits) splitString ",";
+			tts_emission_waveSpeed = parseNumber (_waveSpeed);
+			tts_emission_approachDirection = ["N", "E", "S", "W"]#(_approachDirection);
+			tts_emission_showEmissionOnMap = _showEmissionOnMap;
+			tts_emission_disableRain = _disableRain;
 
 			{publicVariable _x;} forEach [ // publish settings to all clients
-				"tts_emission_emissionType",
+				//"tts_emission_emissionType",
 				"tts_emission_playerEffect",
 				"tts_emission_aiEffect",
+				"tts_emission_vehicleEffect",
 				"tts_emission_aircraftEffect",
 				"tts_emission_sirenType",
 				"tts_emission_useSirenObject",

--- a/scripts/tts_emission/functions/zen/fn_zen_moduleStartRandomEmissions.sqf
+++ b/scripts/tts_emission/functions/zen/fn_zen_moduleStartRandomEmissions.sqf
@@ -7,7 +7,7 @@
 		[ // array of controls for dialog
 			["EDIT", ["STR_tts_emission_moduleStartRandomEmissions_minDelay", "STR_tts_emission_moduleStartRandomEmissions_minDelay_desc"],
 				[ // control args
-					"1800", // default text
+					"30", // default text
 					{}, // sanitise function
 					1 // edit box height (only for multi line)
 				],
@@ -15,7 +15,7 @@
 			],
 			["EDIT", ["STR_tts_emission_moduleStartRandomEmissions_maxDelay", "STR_tts_emission_moduleStartRandomEmissions_maxDelay_desc"],
 				[ // control args
-					"2700", // default text
+					"45", // default text
 					{}, // sanitise function
 					1 // edit box height (only for multi line)
 				],

--- a/stringtable.xml
+++ b/stringtable.xml
@@ -120,6 +120,28 @@
                     <Korean>방사능 방출에 플레이어가 아닌 인공지능에게 어떤 영향을 미치게 하실건가요?</Korean>
                 </Key>
             </Container>
+            <Container name="Vehicle effect param">
+                <Key ID="STR_tts_emission_moduleChangeSettings_vehicleEffect">
+                    <Original>Vehicle effect</Original>
+                    <English>Vehicle effect</English>
+                </Key>
+                <Key ID="STR_tts_emission_moduleChangeSettings_vehicleEffect_desc">
+                    <Original>How does the emission affect vehicles?</Original>
+                    <English>How does the emission affect vehicles?</English>
+                </Key>
+                <Key ID="STR_tts_emission_moduleChangeSettings_vehicleEffect_disableEngine">
+                    <Original>Disable engine</Original>
+                    <English>Disable engine</English>
+                </Key>
+                <Key ID="STR_tts_emission_moduleChangeSettings_vehicleEffect_lightningBolt_engineOn">
+                    <Original>Lightning bolt (if engine is on)</Original>
+                    <English>Lightning bolt (if engine is on)</English>
+                </Key>
+                <Key ID="STR_tts_emission_moduleChangeSettings_vehicleEffect_disableEngine_engineOn">
+                    <Original>Disable engine (if engine is on)</Original>
+                    <English>Disable engine (if engine is on)</English>
+                </Key>
+            </Container>
             <Container name="Aircraft effect param">
                 <Key ID="STR_tts_emission_moduleChangeSettings_aircraftEffect">
                     <Original>Aircraft effect</Original>


### PR DESCRIPTION
- Fixed distance emission is no longer supported.
- Camera shake is now tied to the camera's distance to the emission wave rather than the player's and sounds are now played relative to the camera.
- Increased audible distance for emission pulse sounds and create them further away so that they are still audible when moving rapidly.
- Adjusted light source attenuation so the sky light isn't concentrated around the player.
- The player is no longer affected by the emission wave if they have damage disabled.
- AI now use the same shelter check as players.
- Added a parameter to select what effect the emission has on non-flying vehicles (ground vehicles/ships/landed aircraft).
- Cleaned up damage related functions so there should be no clash between player/AI effect and aircraft/vehicle effect parameters.
- Fixed an issue where lightning bolts would not appear correctly in multiplayer.
- Static weapons are not affected by the emission.
- Updated default settings for 'Start Random Emissions' ZEN module (defaults were still in seconds rather than minutes).