### PR TITLE
ace AI unconscious fix (mod)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 ## Changelog
 Read below for complete changelog history.
 
+### 14/12/2024
+- Fixed an issue where AI might get stuck in the unconscious animation when ACE is enabled. (Thanks SilenceIsFatto)
+
 ### 18/02/2022
 Applied changes from script version:
 - Fixed distance emission is no longer supported.

--- a/tts_emission/functions/fn_damageNonPlayer.sqf
+++ b/tts_emission/functions/fn_damageNonPlayer.sqf
@@ -121,12 +121,7 @@ sleep 15; // small sleep to simulate unconscious period
 			[_unit, _x] remoteExec ["enableAI", _unit, false];
 		};
 	} forEach ["MOVE", "AUTOTARGET", "TARGET", "WEAPONAIM"];
-
-	if (_ace_enabled) then { // ace does some weird stuff with playMove, AI never wake up as a result
-		[_unit, "AmovPpneMstpSnonWnonDnon"] remoteExec ["switchMove", _unit, false];
-	} else {
-		[_unit, "AmovPpneMstpSnonWnonDnon"] remoteExec ["playMove", _unit, false];
-	};
+	[_unit, "AmovPpneMstpSnonWnonDnon"] remoteExec ["switchMove", _unit, false];
 	
 	_unit setVariable ["tts_emission_ai_isUnconscious", false, true];
 } forEach _disabledUnits;

--- a/tts_emission/functions/fn_damageNonPlayer.sqf
+++ b/tts_emission/functions/fn_damageNonPlayer.sqf
@@ -121,6 +121,12 @@ sleep 15; // small sleep to simulate unconscious period
 			[_unit, _x] remoteExec ["enableAI", _unit, false];
 		};
 	} forEach ["MOVE", "AUTOTARGET", "TARGET", "WEAPONAIM"];
-	[_unit, "AmovPpneMstpSnonWnonDnon"] remoteExec ["playMove", _unit, false];
+
+	if (_ace_enabled) then { // ace does some weird stuff with playMove, AI never wake up as a result
+		[_unit, "AmovPpneMstpSnonWnonDnon"] remoteExec ["switchMove", _unit, false];
+	} else {
+		[_unit, "AmovPpneMstpSnonWnonDnon"] remoteExec ["playMove", _unit, false];
+	};
+	
 	_unit setVariable ["tts_emission_ai_isUnconscious", false, true];
 } forEach _disabledUnits;


### PR DESCRIPTION
# The problem:

After some testing, it seems that with `tts_emission_aiEffect = 1;` and ace enabled, AI will never wake up.

I've narrowed this down to 'playMove', as for whatever reason this just doesn't work with ace.

# The (potential) solution:

By swapping to 'switchMove' when _ace_enabled returns true, it appears to fix this issue.

**Basically a duplicate of #2, but works with the mod branch**